### PR TITLE
Fixed issue #3 where atob is not defined in node-webkit

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var hasArrayBufferView = new Blob([new Uint8Array(100)]).size == 100;
 
 module.exports = function(uri){
   var data = uri.split(',')[1];
-  var bytes = atob(data);
+  var bytes = typeof atob === 'undefined' ? window.atob(data) : atob(data);
   var buf = new ArrayBuffer(bytes.length);
   var arr = new Uint8Array(buf);
   for (var i = 0; i < bytes.length; i++) {


### PR DESCRIPTION
Fixed issue #3 where atob is not defined in node-webkit by first checking for its existence in case it is defined, then trying window.atob if atob is undefined.

I coded this so it is backwards compatible with whatever may have been using atob in the first place.  I make no assumptions about it being undefined in other environments and first check before using window.atob.
